### PR TITLE
Port to Raspbian 2025-05-13

### DIFF
--- a/assets/SheepShaver-RPi-fix-natmem-offset.patch
+++ b/assets/SheepShaver-RPi-fix-natmem-offset.patch
@@ -1,0 +1,17 @@
+diff --git a/SheepShaver/src/Unix/configure.ac b/SheepShaver/src/Unix/configure.ac
+https://github.com/kanjitalk755/macemu/commit/6bbfa4dd5688a2ddf537c385b02d9b0d06c0ea45.diff
+index 0ff429759..78efc9ac3 100644
+--- a/SheepShaver/src/Unix/configure.ac
++++ b/SheepShaver/src/Unix/configure.ac
+@@ -1282,9 +1282,9 @@ int main(void)
+ EOF
+   doit='$CXX conftest.$ac_ext -o conftest.$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS $LIBS $NATMEM_OFFSET_DEF >& AS_MESSAGE_LOG_FD'
+   if AC_TRY_EVAL(doit); then
+-    NATMEM_OFFSET=`./conftest.$ac_exeext`
++    NATMEM_OFFSET=0x10000000
+   else
+-    NATMEM_OFFSET=
++    NATMEM_OFFSET=0x10000000
+   fi
+   rm -f conftest*
+   AC_LANG_RESTORE

--- a/assets/func.sh
+++ b/assets/func.sh
@@ -17,6 +17,7 @@
 VERSION="1.4.1"
 
 # Dirs
+ASSETS_DIR="$( realpath $( dirname "${BASH_SOURCE}" ) )"
 BASE_DIR="/usr/share/macintoshpi"
 CONF_DIR="/etc/macintoshpi"
 WAV_DIR="${BASE_DIR}/sounds"
@@ -25,16 +26,16 @@ SRC_DIR="${BASE_DIR}/src"
 # Basilisk II
 BASILISK_REPO="https://github.com/kanjitalk755/macemu"
 BASILISK_FILE="/usr/local/bin/BasiliskII"
-BASILISK_REVISION="33c3419"
+BASILISK_REVISION="44bf57e79151d11af6f2c30997f507313e8751cf"
 
 # SheepShaver
 SHEEPSHAVER_REPO=${BASILISK_REPO}
 SHEEPSHAVER_FILE="/usr/local/bin/SheepShaver"
-SHEEPSHAVER_REVISION="2d022df81177ca05b259598e2a1345a9309de096"
+SHEEPSHAVER_REVISION="44bf57e79151d11af6f2c30997f507313e8751cf"
 
 # SDL2
-SDL2_VERSION="2.0.8"
-SDL2_SONAME="0.8.0"
+SDL2_VERSION="2.32.10"
+SDL2_SONAME="0.3200.10"
 SDL2_SOURCE="https://www.libsdl.org/release/SDL2-${SDL2_VERSION}.tar.gz"
 SDL2_FILE="/usr/local/lib/libSDL2-2.0.so.${SDL2_SONAME}"
 
@@ -50,14 +51,16 @@ VICE_SOURCE="https://downloads.sourceforge.net/project/vice-emu/releases/vice-${
 
 # CDEmu
 CDEMU_REPO="https://github.com/cdemu/cdemu.git"
-CDEMU_REVISION="vhba-module-20210418"
+CDEMU_REVISION="vhba-module-20250329"
 
 # Vmodem
-TTY0TTY_VERSION="1.2"
+TCPSER_VERSION="1.1.4"
+TCPSER_SOURCE="https://github.com/go4retro/tcpser/archive/refs/tags/v${TCPSER_VERSION}.tar.gz"
+TTY0TTY_VERSION="1.3.0"
 TTY0TTY_SOURCE="https://github.com/freemed/tty0tty/archive/refs/tags/${TTY0TTY_VERSION}.tar.gz"
 
 # SyncTERM
-SYNCTERM_VERSION="1.1"
+SYNCTERM_VERSION="1.6"
 SYNCTERM_SOURCE="https://sourceforge.net/projects/syncterm/files/syncterm/syncterm-${SYNCTERM_VERSION}/syncterm-${SYNCTERM_VERSION}-src.tgz/download"
 
 # HDD images and ROMs
@@ -186,6 +189,7 @@ cd ${SRC_DIR}/macemu/SheepShaver
 make links
 cd src/Unix
 
+patch -p4 < "${ASSETS_DIR}/SheepShaver-RPi-fix-natmem-offset.patch"
 NO_CONFIGURE=1 ./autogen.sh &&
 ./configure --enable-sdl-audio \
             --enable-sdl-video \
@@ -221,6 +225,9 @@ printf "\e[95m"; echo '
 
 '; printf "\e[0m"; sleep 2
 
+sudo apt install -y libmpfr-dev
+[ $? -ne 0 ] && net_error "Basilisk II apt packages"
+
 mkdir -p ${SRC_DIR} 2>/dev/null
 
 cd ${SRC_DIR}
@@ -231,7 +238,7 @@ cd ${SRC_DIR}/macemu/BasiliskII/src/Unix/
 NO_CONFIGURE=1 ./autogen.sh &&
 ./configure --enable-sdl-audio --enable-sdl-framework \
             --enable-sdl-video --disable-vosf \
-            --without-mon --without-esd --without-gtk --disable-nls &&
+            --without-mon --without-esd --without-gtk &&
 make -j3
 sudo make install
 
@@ -274,7 +281,6 @@ cd ${SRC_DIR}/SDL2-${SDL2_VERSION} &&
             --disable-video-x11 \
             --disable-pulseaudio \
             --disable-esd \
-            --disable-video-mir \
             --disable-video-wayland \
             --enable-video-kmsdrm \
             --enable-alsa \

--- a/assets/func.sh
+++ b/assets/func.sh
@@ -45,7 +45,7 @@ SDL2_IMAGE_SOURCE="https://www.libsdl.org/projects/SDL_image/release/SDL2_image-
 SDL2_IMAGE_FILE="/usr/local/lib/libSDL2_image-2.0.so.${SDL2_IMAGE_SONAME}"
 
 # VICE
-VICE_VERSION="3.5"
+VICE_VERSION="3.9"
 VICE_SOURCE="https://downloads.sourceforge.net/project/vice-emu/releases/vice-${VICE_VERSION}.tar.gz"
 
 # CDEmu

--- a/assets/func.sh
+++ b/assets/func.sh
@@ -34,6 +34,7 @@ ROM4OS[9]="https://smb4.s3.us-west-2.amazonaws.com/sheepshaver/apple_roms/newwor
 
 
 function usercheck {
+  return true
   [ $USER != "pi" ] && echo 'Run this script as the "pi" user.' && exit
 }
 
@@ -90,12 +91,12 @@ function net_error {
 
 
 function Base_dir {
-   [ -d ${BASE_DIR} ] || ( sudo mkdir -p ${BASE_DIR} && sudo chown pi:pi ${BASE_DIR} )
+   [ -d ${BASE_DIR} ] || ( sudo mkdir -p ${BASE_DIR} && sudo chown $USER:$USER ${BASE_DIR} )
 }
 
 
 function Src_dir {
-   [ -d ${SRC_DIR} ] || ( sudo mkdir -p ${SRC_DIR} && sudo chown pi:pi ${SRC_DIR} )
+   [ -d ${SRC_DIR} ] || ( sudo mkdir -p ${SRC_DIR} && sudo chown $USER:$USER ${SRC_DIR} )
 }
 
 function Build_NetDriver {
@@ -112,7 +113,7 @@ printf "\e[95m"; echo '
 cd Linux/NetDriver
 make
 sudo make dev
-sudo chown pi /dev/sheep_net
+sudo chown $USER /dev/sheep_net
 sudo make install
 sudo modprobe sheep_net
 
@@ -217,7 +218,7 @@ sudo apt install -y automake gobjc libudev-dev xa65 build-essential byacc texi2h
 Base_dir
 mkdir -p ${SRC_DIR}
 
-[ -d "/home/pi/Downloads" ] || mkdir /home/pi/Downloads
+[ -d "/home/$USER/Downloads" ] || mkdir /home/$USER/Downloads
 
 wget ${SDL2_SOURCE} -O - | tar -xz -C ${SRC_DIR}
 [ $? -ne 0 ] && net_error "SDL2 sources"

--- a/assets/func.sh
+++ b/assets/func.sh
@@ -22,10 +22,12 @@ SRC_DIR="${BASE_DIR}/src"
 BASILISK_REPO="https://github.com/kanjitalk755/macemu"
 SHEEPSHAVER_REPO=${BASILISK_REPO}
 SDL2_SOURCE="https://www.libsdl.org/release/SDL2-2.0.7.tar.gz"
+SDL2_IMAGE_SOURCE="https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz"
 VICE_SOURCE="https://downloads.sourceforge.net/project/vice-emu/releases/vice-3.4.tar.gz"
 BASILISK_FILE="/usr/local/bin/BasiliskII"
 SHEEPSHAVER_FILE="/usr/local/bin/SheepShaver"
 SDL2_FILE="/usr/local/lib/libSDL2-2.0.so.0.7.0"
+SDL2_IMAGE_FILE="/usr/local/lib/libSDL2_image-2.0.so.0.5.0"
 HDD_IMAGES="https://homer-retro.space/appfiles"
 ASOFT="${HDD_IMAGES}/as/asoft.tar.gz"
 ROM4OS[7]="https://github.com/macmade/Macintosh-ROMs/raw/18e1d0a9756f8ae3b9c005a976d292d7cf0a6f14/Performa-630.ROM"
@@ -234,6 +236,38 @@ cd ${SRC_DIR}/SDL2-2.0.7 &&
             --enable-video-kmsdrm \
             --enable-alsa \
             --enable-audio &&
+make -j3
+sudo make install
+
+rm -rf ${SRC_DIR}
+
+}
+
+
+function Build_SDL2_image {
+
+printf "\e[95m"; echo '
+ ____  ____  _     ____      _
+/ ___||  _ \| |   |___ \    (_)_ __ ___   __ _  __ _  ___
+\___ \| | | | |     __) |   | |  _   _ \ / _  |/ _  |/ _ \
+ ___) | |_| | |___ / __/    | | | | | | | (_| | (_| |  __/
+|____/|____/|_____|_____|   |_|_| |_| |_|\__,_|\__, |\___|
+                                              |___/
+
+'; printf "\e[0m"; sleep 2
+
+sudo apt install -y libjpeg-dev libpng-dev libtiff-dev libwebp-dev
+
+[ $? -ne 0 ] && net_error "SDL2_image apt packages"
+
+Base_dir
+mkdir -p ${SRC_DIR}
+
+wget ${SDL2_IMAGE_SOURCE} -O - | tar -xz -C ${SRC_DIR}
+[ $? -ne 0 ] && net_error "SDL2_image sources"
+
+cd ${SRC_DIR}/SDL2_image-2.0.5 && 
+./configure --host=arm-raspberry-linux-gnueabihf &&
 make -j3
 sudo make install
 

--- a/assets/func.sh
+++ b/assets/func.sh
@@ -70,6 +70,16 @@ ROM4OS[7]="https://github.com/macmade/Macintosh-ROMs/raw/18e1d0a9756f8ae3b9c005a
 ROM4OS[8]="https://github.com/macmade/Macintosh-ROMs/raw/main/Quadra-650.ROM"
 ROM4OS[9]="https://smb4.s3.us-west-2.amazonaws.com/sheepshaver/apple_roms/newworld86.rom.zip"
 
+# Parse command line arguments for debug mode.
+for arg in "$@"; do
+    case $arg in
+        --debug)
+            export DEBUG=1
+            shift
+            ;;
+    esac
+done
+
 # Functions
 function usercheck {
   return 0
@@ -138,8 +148,7 @@ function Src_dir {
 }
 
 function Cleanup {
-    # Debug-aware cleanup routine
-    # Only cleanup if DEBUG is not set or is not "1"
+    # Only clean up sources and built files if DEBUG is not set to "1".
     if [ "${DEBUG:-0}" != "1" ]; then
         rm -rf ${SRC_DIR}
     else

--- a/assets/func.sh
+++ b/assets/func.sh
@@ -34,7 +34,7 @@ ROM4OS[9]="https://smb4.s3.us-west-2.amazonaws.com/sheepshaver/apple_roms/newwor
 
 
 function usercheck {
-  return true
+  return 0
   [ $USER != "pi" ] && echo 'Run this script as the "pi" user.' && exit
 }
 

--- a/assets/func.sh
+++ b/assets/func.sh
@@ -136,7 +136,7 @@ cd ${SRC_DIR}
 rm -rf macemu 2>/dev/null
 git clone ${BASILISK_REPO}
 cd ${SRC_DIR}/macemu
-git checkout 33c3419
+git checkout 2d022df81177ca05b259598e2a1345a9309de096
 cd ${SRC_DIR}/macemu/SheepShaver
 make links
 cd src/Unix

--- a/cdemu/cdemu.sh
+++ b/cdemu/cdemu.sh
@@ -29,7 +29,7 @@ updateinfo
 sudo apt-get install -y dpkg-dev dkms libao-dev intltool libsndfile1-dev libbz2-dev \
                         liblzma-dev gtk-doc-tools gobject-introspection libgirepository1.0-dev \
                         python3-matplotlib libsamplerate0-dev cmake raspberrypi-kernel-headers \
-                        dh-systemd
+                        dh-dkms dh-python
 
 [ $? -ne 0 ] && net_error "CDEmu apt packages"
 
@@ -51,9 +51,9 @@ sudo dpkg -i vhba-dkms*.deb
 cd ${SRC_DIR}/cdemu/libmirage
 dpkg-buildpackage -b -uc -tc
 cd ..
-sudo dpkg -i libmirage11*.deb
+sudo dpkg -i libmirage*.deb
 sudo dpkg -i gir1.2-mirage*.deb
-sudo dpkg -i libmirage11-dev*.deb
+sudo dpkg -i libmirage*-dev*.deb
 
 
 # cdemu-daemon

--- a/cdemu/cdemu.sh
+++ b/cdemu/cdemu.sh
@@ -22,7 +22,7 @@ printf "\e[92m"; echo '
  \____|____/|_____|_| |_| |_|\__,_|
 '; printf "\e[0m"; sleep 2
 
-source ./assets/func.sh
+source ../assets/func.sh
 updateinfo
 
 # Software
@@ -34,19 +34,21 @@ sudo apt-get install -y dpkg-dev dkms libao-dev intltool libsndfile1-dev libbz2-
 [ $? -ne 0 ] && net_error "CDEmu apt packages"
 
 # CDemu git repo
-rm -rf ~/cdemusrc
-git clone -b 'vhba-module-20210418' --single-branch --depth 1 https://github.com/cdemu/cdemu.git ~/cdemusrc
+Base_dir
+Src_dir
+rm -rf ${SRC_DIR}/cdemu
+git clone -b ${CDEMU_REVISION} --single-branch --depth 1 ${CDEMU_REPO} ${SRC_DIR}/cdemu
 [ $? -ne 0 ] && net_error "CDEmu sources"
 
 # vhba-module
-cd ~/cdemusrc/vhba-module
+cd ${SRC_DIR}/cdemu/vhba-module
 dpkg-buildpackage -b -uc -tc
 cd ..
 sudo dpkg -i vhba-dkms*.deb
 
 
 # libmirage
-cd ~/cdemusrc/libmirage
+cd ${SRC_DIR}/cdemu/libmirage
 dpkg-buildpackage -b -uc -tc
 cd ..
 sudo dpkg -i libmirage11*.deb
@@ -55,7 +57,7 @@ sudo dpkg -i libmirage11-dev*.deb
 
 
 # cdemu-daemon
-cd ~/cdemusrc/cdemu-daemon
+cd ${SRC_DIR}/cdemu/cdemu-daemon
 dpkg-buildpackage -b -uc -tc
 cd ..
 sudo dpkg -i cdemu-daemon_*.deb
@@ -63,20 +65,18 @@ sudo dpkg -i cdemu-daemon-dbg*.deb
 
 
 # cdemu-client
-cd ~/cdemusrc/cdemu-client
+cd ${SRC_DIR}/cdemu/cdemu-client
 dpkg-buildpackage -b -uc -tc
 cd ..
 sudo dpkg -i cdemu-client_*.deb
 
 
 # image-analyzer
-cd ~/cdemusrc/image-analyzer
+cd ${SRC_DIR}/cdemu/image-analyzer
 dpkg-buildpackage -b -uc -tc
 cd ..
 sudo dpkg -i image-analyzer_*.deb
-
-cd ~/
-rm -rf ~/cdemusrc
+Cleanup
 
 cat << EOF > /tmp/cdload
 #!/bin/sh

--- a/launcher/config/os7-342/etc/rc.local
+++ b/launcher/config/os7-342/etc/rc.local
@@ -17,5 +17,5 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os7 macpiautostart" &
+su $USER -c "mac os7 macpiautostart" &
 exit 0

--- a/launcher/config/os7-384/etc/rc.local
+++ b/launcher/config/os7-384/etc/rc.local
@@ -17,5 +17,5 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os7 macpiautostart" &
+su $USER -c "mac os7 macpiautostart" &
 exit 0

--- a/launcher/config/os7-480/etc/rc.local
+++ b/launcher/config/os7-480/etc/rc.local
@@ -17,5 +17,5 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os7 macpiautostart" &
+su $USER -c "mac os7 macpiautostart" &
 exit 0

--- a/launcher/config/os7-600/etc/rc.local
+++ b/launcher/config/os7-600/etc/rc.local
@@ -17,5 +17,5 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os7 macpiautostart" &
+su $USER -c "mac os7 macpiautostart" &
 exit 0

--- a/launcher/config/os8-480/etc/rc.local
+++ b/launcher/config/os8-480/etc/rc.local
@@ -17,6 +17,6 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os8 macpiautostart" &
+su $USER -c "mac os8 macpiautostart" &
 
 exit 0

--- a/launcher/config/os8-600/etc/rc.local
+++ b/launcher/config/os8-600/etc/rc.local
@@ -17,6 +17,6 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os8 macpiautostart" &
+su $USER -c "mac os8 macpiautostart" &
 
 exit 0

--- a/launcher/config/os9-480/etc/rc.local
+++ b/launcher/config/os9-480/etc/rc.local
@@ -17,6 +17,6 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os9 macpiautostart" &
+su $USER -c "mac os9 macpiautostart" &
 
 exit 0

--- a/launcher/config/os9-600/etc/rc.local
+++ b/launcher/config/os9-600/etc/rc.local
@@ -17,6 +17,6 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os9 macpiautostart" &
+su $USER -c "mac os9 macpiautostart" &
 
 exit 0

--- a/launcher/config/os9-768/etc/rc.local
+++ b/launcher/config/os9-768/etc/rc.local
@@ -17,6 +17,6 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "mac os9 macpiautostart" &
+su $USER -c "mac os9 macpiautostart" &
 
 exit 0

--- a/launcher/config/syncterm/etc/rc.local
+++ b/launcher/config/syncterm/etc/rc.local
@@ -17,6 +17,6 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
-su pi -c "syncterm -iSF"
+su $USER -c "syncterm -iSF"
 
 exit 0

--- a/launcher/mac
+++ b/launcher/mac
@@ -39,7 +39,7 @@
     function log_check {
         if ! [ -f ${LOG} ]; then
             sudo touch ${LOG}
-            sudo chown pi:pi ${LOG}
+            sudo chown $USER:$USER ${LOG}
         fi
         echo -e "\n$(date): $SYS ----------" >> ${LOG}
     }

--- a/macos9/macos9.sh
+++ b/macos9/macos9.sh
@@ -32,8 +32,8 @@ sudo apt install -y libdirectfb-dev automake gobjc libudev-dev xa65 build-essent
                     texinfo libxaw7-dev libgtk2.0-cil-dev libgtkglext1-dev libpulse-dev \
                     bison libnet1 libnet1-dev libpcap0.8 libpcap0.8-dev libvte-dev \
                     libasound2-dev raspberrypi-kernel-headers build-essential git \
-                    libgtk2.0-dev x11proto-xf86dga-dev libesd0-dev libxxf86dga-dev \
-                    libxxf86dga1 libsdl1.2-dev 
+                    libgtk2.0-dev x11proto-xf86dga-dev libxxf86dga-dev \
+                    libxxf86dga1 libsdl1.2-dev # libesd0-dev was originally required too
 
 [ $? -ne 0 ] && net_error "Mac OS 9 apt packages"
 

--- a/syncterm/syncterm.sh
+++ b/syncterm/syncterm.sh
@@ -22,28 +22,27 @@ printf "\e[92m"; echo '
 |____/ \__, |_| |_|\___||_| |_____|_| \_\_|  |_|
        |___/                                    
 '; printf "\e[0m"; sleep 2
-source ./assets/func.sh
+source ../assets/func.sh
 updateinfo
 
-BDIR=~/syncterm-build
-mkdir $BDIR
+Base_dir
+Src_dir
 
 sudo apt install -y libncurses5-dev libsdl1.2-dev build-essential libsdl2-dev
 [ $? -ne 0 ] && net_error "SyncTERM apt packages"
 
-wget https://sourceforge.net/projects/syncterm/files/syncterm/syncterm-1.1/syncterm-1.1-src.tgz/download -O $BDIR/syncterm.tgz
+wget ${SYNCTERM_SOURCE} -O ${SRC_DIR}/syncterm.tgz
 
 [ $? -ne 0 ] && net_error "SyncTERM sources"
 
-cd $BDIR
+cd ${SRC_DIR}
 
 tar -xf syncterm.tgz
-cd syncterm-1.1/src/syncterm
+cd syncterm-${SYNCTERM_VERSION}/src/syncterm
 sudo make USE_SDL=1 NO_X=1
 sudo make install
-cd /
-sleep 2
-sudo rm -rf $BDIR
+
+Cleanup
 
 printf "\e[92m";
 echo *** all done ***

--- a/vice/vice.sh
+++ b/vice/vice.sh
@@ -37,6 +37,9 @@ sudo apt install -y wget netcat-traditional automake gobjc libudev-dev xa65 buil
 # SDL2 check && builder
 [ -f $SDL2_FILE ] || Build_SDL2;
 
+# SDL2_image check && builder
+[ -f $SDL2_IMAGE_FILE ] || Build_SDL2_image;
+
 # VICE
 
 mkdir -p ${SRC_DIR} 2>/dev/null

--- a/vice/vice.sh
+++ b/vice/vice.sh
@@ -52,7 +52,8 @@ cd ${SRC_DIR}/vice-${VICE_VERSION}
             --enable-sdlui2 \
             --enable-ethernet \
             --enable-rs232 \
-            --disable-pdf-docs
+            --disable-pdf-docs \
+            --without-libcurl
 make
 sudo make install
 

--- a/vice/vice.sh
+++ b/vice/vice.sh
@@ -25,10 +25,12 @@ __     _____ ____ _____
 source ../assets/func.sh
 updateinfo
 # Packages
-sudo apt install -y wget tcpser netcat automake gobjc libudev-dev xa65 build-essential byacc \
+sudo apt install -y wget netcat-traditional automake gobjc libudev-dev xa65 build-essential byacc \
                     texi2html flex libreadline-dev libxaw7-dev texinfo libxaw7-dev libgtk2.0-cil-dev \
                     libgtkglext1-dev libpulse-dev bison libnet1 libnet1-dev libpcap0.8 libpcap0.8-dev \
                     libvte-dev libasound2-dev
+# FIXME tcpser must be compiled from source at http://www.jbrain.com/pub/linux/serial/.
+# It is not available as a package anymore.
 
 [ $? -ne 0 ] && net_error "VICE apt packages"
 

--- a/vice/vice.sh
+++ b/vice/vice.sh
@@ -46,14 +46,18 @@ mkdir -p ${SRC_DIR} 2>/dev/null
 wget ${VICE_SOURCE} -O - | tar -xz -C ${SRC_DIR}
 [ $? -ne 0 ] && net_error "VICE sources"
 
-cd ${SRC_DIR}/vice-3.4
+cd ${SRC_DIR}/vice-${VICE_VERSION}
 ./configure --without-pulse \
             --with-sdlsound \
             --enable-sdlui2 \
             --enable-ethernet \
-            --enable-rs232
+            --enable-rs232 \
+            --disable-pdf-docs
 make
 sudo make install
-rm -rf ${SRC_DIR}
+
+# Debug-aware cleanup
+Cleanup
+
 echo '* done'
 

--- a/vmodem/vmodem.sh
+++ b/vmodem/vmodem.sh
@@ -25,10 +25,22 @@ __     ___      _               _    __  __           _
 '; printf "\e[0m"; sleep 2
 source ../assets/func.sh
 updateinfo
-sudo apt install -y tcpser raspberrypi-kernel-headers build-essential
-[ $? -ne 0 ] && net_error "VICE apt packages"
+sudo apt install -y raspberrypi-kernel-headers build-essential
+[ $? -ne 0 ] && net_error "Virutal Modem apt packages"
 Base_dir
 Src_dir
+
+# Installation of tcpser.
+wget ${TCPSER_SOURCE} -O ${SRC_DIR}/tcpser-${TCPSER_VERSION}.tar.gz
+[ $? -ne 0 ] && net_error "tcpser sources"
+cd ${SRC_DIR}
+tar zxf tcpser-${TCPSER_VERSION}.tar.gz
+cd tcpser-${TCPSER_VERSION}
+make
+sudo cp tcpser /usr/local/bin/
+sudo chmod 655 /usr/local/bin/tcpser
+
+# Installation of tty0tty.
 wget ${TTY0TTY_SOURCE} -O ${SRC_DIR}/tty0tty-${TTY0TTY_VERSION}.tar.gz
 [ $? -ne 0 ] && net_error "tty0tty sources"
 cd ${SRC_DIR}
@@ -67,7 +79,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/vmodem.conf
-ExecStart=/usr/bin/tcpser -d /dev/tnt0 -S \$BPS -l \$LOG_LEVEL -L \$LOG_FILE
+ExecStart=/usr/local/bin/tcpser -d /dev/tnt0 -S \$BPS -l \$LOG_LEVEL -L \$LOG_FILE
 ExecStartPre=/usr/bin/chmod 666 /dev/tnt0
 ExecStartPre=/usr/bin/chmod 666 /dev/tnt1
 ExecStartPost=/bin/sleep 1

--- a/vmodem/vmodem.sh
+++ b/vmodem/vmodem.sh
@@ -14,8 +14,6 @@
 # Virtual Modem - auto-compile/install script
 # -------------------------------------------
 
-BDIR=~/vmodem-build
-
 printf "\e[92m"; echo '
 ** MacintoshPi
 __     ___      _               _    __  __           _                
@@ -25,16 +23,17 @@ __     ___      _               _    __  __           _
    \_/  |_|_|   \__|\__,_|\__,_|_|  |_|  |_|\___/ \__,_|\___|_| |_| |_|
                                                                           
 '; printf "\e[0m"; sleep 2
-source ./assets/func.sh
+source ../assets/func.sh
 updateinfo
 sudo apt install -y tcpser raspberrypi-kernel-headers build-essential
 [ $? -ne 0 ] && net_error "VICE apt packages"
-mkdir $BDIR && cd $BDIR
-wget https://github.com/freemed/tty0tty/archive/refs/tags/1.2.tar.gz -O ${BDIR}/tty0tty-1.2.tar.gz
+Base_dir
+Src_dir
+wget ${TTY0TTY_SOURCE} -O ${SRC_DIR}/tty0tty-${TTY0TTY_VERSION}.tar.gz
 [ $? -ne 0 ] && net_error "tty0tty sources"
-cd $BDIR
-tar zxf tty0tty-1.2.tar.gz
-cd tty0tty-1.2/module
+cd ${SRC_DIR}
+tar zxf tty0tty-${TTY0TTY_VERSION}.tar.gz
+cd tty0tty-${TTY0TTY_VERSION}/module
 make
 sudo cp tty0tty.ko /lib/modules/$(uname -r)/kernel/drivers/misc/
 sudo depmod
@@ -82,8 +81,8 @@ EOF
 sudo mv vmodem.service /lib/systemd/system
 sudo mv vmodem.conf /etc
 sudo chmod 666 /etc/vmodem.conf
-cd ~/
-rm -rf $BDIR
+
+Cleanup
 
 sudo systemctl enable --now vmodem.service
 


### PR DESCRIPTION
Hello, I would like to request merging this update of your greatly helpful MacintoshPi project to the current version of Raspbian OS (reference 2025-05-13) based on Debian 12 Bookworm. The update contains some fixes, updated packages and their dependencies without which none of the emulators would currently compile or launch. I have also added a `--debug` switch I have found helpful when debugging all of the mentioned issues and support for systems without the default user account _pi._

The update was tested on Raspberry Zero 2W with the aforementioned Raspbian OS in its Full configuration, booted into a console although I do tend to thing that the Lite version should actually be sufficient for that. Reasons why I retried building the entire project on a Full variant of the OS were irreparable issues I eventually solved with these changes. The migration to Raspbian Full did not actually have any impact on these.

Thank you for your work and best regards from me.